### PR TITLE
Add example manifests for deploying to Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Or if you're using Nix flakes:
 nix profile install github:zombiezen/tailscale-lb
 ```
 
+If you are deploying to Kubernetes, example manifests are provided in the `deploy` folder that can also be built with `kustomize`. Make sure to update the value of `TAILSCALE_AUTH_KEY` in secret.yaml to be an authentication key that you have generated from your [Tailscale Console][].
+
+```shell
+kubectl apply -k deploy
+```
+
+[Tailscale Console]: https://login.tailscale.com/admin/settings/keys
 [Docker]: https://www.docker.com/
 [GitHub Container Registry]: https://github.com/zombiezen/tailscale-lb/pkgs/container/tailscale-lb
 [Nix]: https://nixos.org/

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  tailscale-lb.ini.tpl: |
+    # This is the hostname that will show up in the Tailscale console
+    # and be used by MagicDNS.
+    hostname = tailscale-lb
+
+    # (Optional) Use an authentication key from https://login.tailscale.com/admin/settings/keys
+    auth-key = ${TAILSCALE_AUTH_KEY}
+
+    [tcp 443]
+    backend = example.com
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: tailscale-lb
+    app.kubernetes.io/instance: tailscale-lb
+  name: tailscale-lb
+  namespace: tailscale-lb

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: tailscale-lb
+    app.kubernetes.io/instance: tailscale-lb
+  name: tailscale-lb
+  namespace: tailscale-lb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-lb
+      app.kubernetes.io/instance: tailscale-lb
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tailscale-lb
+        app.kubernetes.io/instance: tailscale-lb
+    spec:
+      containers:
+        - image: ghcr.io/zombiezen/tailscale-lb:latest
+          imagePullPolicy: IfNotPresent
+          name: tailscale-lb
+          args:
+            - /etc/tailscale/tailscale-lb.ini
+          resources: {}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/tailscale
+      initContainers:
+        - image: alpine:latest
+          imagePullPolicy: IfNotPresent
+          name: config
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk -q update && apk -q add gettext
+              envsubst < /tmp/config-template/tailscale-lb.ini.tpl | cat > /tmp/config/tailscale-lb.ini
+          envFrom:
+            - secretRef:
+                name: tailscale-lb
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config
+            - name: config-template
+              mountPath: /tmp/config-template
+      volumes:
+        - name: config
+          emptyDir: {}
+        - name: config-template
+          configMap:
+            name: tailscale-lb
+      restartPolicy: Always

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - namespace.yaml
+  - secret.yaml
+  - serviceaccount.yaml

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: tailscale-lb
+    name: tailscale-lb
+  name: tailscale-lb

--- a/deploy/secret.yaml
+++ b/deploy/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  TAILSCALE_AUTH_KEY: Q0hBTkdFTUUK
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: tailscale-lb
+    app.kubernetes.io/instance: tailscale-lb
+  name: tailscale-lb
+  namespace: tailscale-lb
+type: Opaque

--- a/deploy/serviceaccount.yaml
+++ b/deploy/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: tailscale-lb
+automountServiceAccountToken: false


### PR DESCRIPTION
I deployed tailscale-lb on my local homelab kubernetes cluster and these are the manifests I used. I figured I'd PR them back to the project in case anyone else was looking for how to deploy on Kubernetes in the future.